### PR TITLE
Align design with sketches

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -38,15 +38,16 @@ const App: FC = () => {
   if (connection && space) {
     return (
       <article className={classes.main}>
-        <WaitingRoom
-          space={space}
-          connection={connection}
-          onStartGame={() => setGameStarted(true)}
-        />
-        {isGameStarted && player && (
+        {isGameStarted && player ? (
           <GameProvider connection={connection} player={player}>
             <Game />
           </GameProvider>
+        ) : (
+          <WaitingRoom
+            space={space}
+            connection={connection}
+            onStartGame={() => setGameStarted(true)}
+          />
         )}
         <ChatPanel messages={messages} onSendMessage={connection.sendMessage} />
       </article>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,12 +19,11 @@ const useStyles = makeStyles({
 });
 
 const App: FC = () => {
-  const { connection, messages, space, player } = useSpace();
+  const { connection, messages, space, player, isGameStarted } = useSpace();
   const connectToSpace = useConnectToSpace();
   const classes = useStyles();
 
   const hasSpaceInUrl = location.pathname !== '/';
-  const [isGameStarted, setGameStarted] = useState(false);
 
   useEffect(() => {
     if (hasSpaceInUrl) {
@@ -43,11 +42,7 @@ const App: FC = () => {
             <Game />
           </GameProvider>
         ) : (
-          <WaitingRoom
-            space={space}
-            connection={connection}
-            onStartGame={() => setGameStarted(true)}
-          />
+          <WaitingRoom space={space} connection={connection} />
         )}
         <ChatPanel messages={messages} onSendMessage={connection.sendMessage} />
       </article>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,6 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+
 import Game from './components/Game';
 import ChatPanel from './components/ChatPanel';
 import { useConnectToSpace, useSpace } from './state/SpaceContext';
@@ -6,11 +8,23 @@ import CreateSpace from './components/CreateSpace';
 import WaitingRoom from './components/WaitingRoom';
 import { GameProvider } from './state/GameContext';
 
+const useStyles = makeStyles({
+  main: {
+    textAlign: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    height: '100%',
+  },
+});
+
 const App: FC = () => {
   const { connection, messages, space, player } = useSpace();
   const connectToSpace = useConnectToSpace();
+  const classes = useStyles();
 
   const hasSpaceInUrl = location.pathname !== '/';
+  const [isGameStarted, setGameStarted] = useState(false);
 
   useEffect(() => {
     if (hasSpaceInUrl) {
@@ -21,24 +35,24 @@ const App: FC = () => {
   if (!(connection || hasSpaceInUrl)) {
     return <CreateSpace />;
   }
-  return (
-    <article>
-      {connection && space && (
-        <>
-          <ChatPanel
-            messages={messages}
-            onSendMessage={connection.sendMessage}
-          />
-          <WaitingRoom space={space} connection={connection} />
-          {player && (
-            <GameProvider connection={connection} player={player}>
-              <Game />
-            </GameProvider>
-          )}
-        </>
-      )}
-    </article>
-  );
+  if (connection && space) {
+    return (
+      <article className={classes.main}>
+        <WaitingRoom
+          space={space}
+          connection={connection}
+          onStartGame={() => setGameStarted(true)}
+        />
+        {isGameStarted && player && (
+          <GameProvider connection={connection} player={player}>
+            <Game />
+          </GameProvider>
+        )}
+        <ChatPanel messages={messages} onSendMessage={connection.sendMessage} />
+      </article>
+    );
+  }
+  return <p>Spinner?</p>;
 };
 
 export default App;

--- a/src/app/api/Connection.ts
+++ b/src/app/api/Connection.ts
@@ -40,4 +40,7 @@ export class Connection {
   sendDrawing = (drawing: Drawing) => {
     this.socket.emit(SocketEvent.Drawing, drawing);
   };
+  startGame = () => {
+    this.socket.emit(SocketEvent.StartGame);
+  };
 }

--- a/src/app/components/CreateSpace.tsx
+++ b/src/app/components/CreateSpace.tsx
@@ -1,13 +1,38 @@
 import React, { FC, useEffect, useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+
 import { Connection } from '../api/Connection';
 import { createSpace } from '../api/space';
 import { useConnectToSpace, useSpace } from '../state/SpaceContext';
+import { Typography } from '@material-ui/core';
 
+const useStyles = makeStyles({
+  main: {
+    textAlign: 'center',
+  },
+  header: {
+    padding: '0.3em',
+  },
+  create: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginTop: '3em',
+    alignItems: 'center',
+  },
+  textField: {
+    width: '100%',
+    maxWidth: '30em',
+    padding: '1em',
+  },
+});
 const CreateSpace: FC = () => {
   const [connection, setConnection] = useState<Connection>();
   const [nickname, setNickname] = useState('');
   const connectToSpace = useConnectToSpace();
   const { setPlayer } = useSpace();
+  const classes = useStyles();
 
   useEffect(() => {
     setConnection(Connection.setupConnection('/'));
@@ -18,22 +43,38 @@ const CreateSpace: FC = () => {
   }
 
   return (
-    <article>
-      <h1>Draw my Guess</h1>
-      <p>Set a nickname</p>
-      <input onChange={(event) => setNickname(event.target.value)} />
-      <button
-        onClick={async () => {
-          const space = await createSpace({
-            hostName: nickname,
-            hostId: connection.socket.id,
-          });
-          setPlayer({ id: space.host.id, name: nickname });
-          connectToSpace(`/${space.id}`);
-        }}
-      >
-        Create game
-      </button>
+    <article className={classes.main}>
+      <Typography className={classes.header} variant="h1">
+        Draw my Guess
+      </Typography>
+      <Typography variant="subtitle1">
+        A game where drawings and guesses are passed around for hysterical
+        results.
+      </Typography>
+      <section className={classes.create}>
+        <Typography>Set a nickname</Typography>
+        <TextField
+          className={classes.textField}
+          placeholder="Nickname"
+          onChange={(event) => setNickname(event.target.value)}
+          variant="outlined"
+        ></TextField>
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          onClick={async () => {
+            const space = await createSpace({
+              hostName: nickname,
+              hostId: connection.socket.id,
+            });
+            setPlayer({ id: space.host.id, name: nickname });
+            connectToSpace(`/${space.id}`);
+          }}
+        >
+          Create game
+        </Button>
+      </section>
     </article>
   );
 };

--- a/src/app/components/CreateSpace.tsx
+++ b/src/app/components/CreateSpace.tsx
@@ -2,11 +2,11 @@ import React, { FC, useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
 
 import { Connection } from '../api/Connection';
 import { createSpace } from '../api/space';
 import { useConnectToSpace, useSpace } from '../state/SpaceContext';
-import { Typography } from '@material-ui/core';
 
 const useStyles = makeStyles({
   main: {

--- a/src/app/components/Game.tsx
+++ b/src/app/components/Game.tsx
@@ -17,7 +17,15 @@ const StyledDrawings = styled.div`
 
 const Game: FC = () => {
   const { game } = useGame();
-  const words = ['ryggsekk', 'couch', 'concert', 'sheep', 'friend', 'plant', 'cake'];
+  const words = [
+    'ryggsekk',
+    'couch',
+    'concert',
+    'sheep',
+    'friend',
+    'plant',
+    'cake',
+  ];
 
   return (
     <>
@@ -26,7 +34,7 @@ const Game: FC = () => {
       <PickAWord key={'cake'} words={words} player={game.players[0]} />
 
       {game.players.map((player: Player) => (
-        <DrawTheWord key={player.id} player={player} />
+        <DrawTheWord key={player.id} />
       ))}
 
       <Typography variant="h2">Drawings</Typography>

--- a/src/app/components/WaitingRoom.tsx
+++ b/src/app/components/WaitingRoom.tsx
@@ -1,53 +1,112 @@
 import React, { FC, useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
 import { Space } from '../../types/models';
 import { useSpace } from '../state/SpaceContext';
 import { Connection } from '../api/Connection';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
 
 interface Props {
   space: Space;
   connection: Connection;
+  onStartGame: () => void;
 }
+const useStyles = makeStyles({
+  main: {
+    textAlign: 'center',
+    height: '100%',
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  header: {
+    padding: '0.3em',
+    textAlign: 'left',
+  },
+  link: {
+    padding: '1em',
+  },
+  nickname: {
+    padding: '1em',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  textField: {
+    width: '100%',
+    maxWidth: '30em',
+    padding: '1em',
+  },
+});
 
 const WaitingRoom: FC<Props> = ({ connection, space }) => {
   const { players, isHost, player, setPlayer } = useSpace();
-  const [nickname, setNickname] = useState(isHost ? space.host.name : '');
-
-  if (isHost) {
-    return (
-      <article>
-        <h1>Draw my Guess</h1>
-        <h2>Welcome, {nickname}!</h2>
-        <p>Share the link with your friends so they can join the game!</p>
-        <a
-          href={`${window.location.origin}/${space.id}`}
-        >{`${window.location.origin}/${space.id}`}</a>
-        <h3>Friends who are here..</h3>
-        {players.map((player) => (
-          <p key={player.id}>{player.name}</p>
-        ))}
-      </article>
-    );
-  }
+  const [nickname, setNickname] = useState('');
+  const classes = useStyles();
 
   return (
-    <article>
-      <h1>Draw my Guess</h1>
-      <h2>Welcome</h2>
-      {!player && (
-        <>
-          <p>Set a nickname</p>
-          <input onChange={(event) => setNickname(event.target.value)} />
-          <button
-            onClick={() => {
-              connection.joinGame(nickname);
-              setPlayer({ id: connection.socket.id, name: nickname });
-            }}
-          >
-            I'm ready!
-          </button>
-        </>
+    <article className={classes.main}>
+      <Typography className={classes.header} variant="h1">
+        Draw my Guess
+      </Typography>
+      {isHost ? (
+        <section className={classes.content}>
+          <Typography variant="h2">{`Welcome, ${space.host.name}!`}</Typography>
+          <section className={classes.link}>
+            <Typography>
+              Share the link with your friends so they can join the game!
+            </Typography>
+            <a
+              href={`${window.location.origin}/${space.id}`}
+            >{`${window.location.origin}/${space.id}`}</a>
+          </section>
+          <Typography variant="h3">Friends who are here...</Typography>
+          {players.map((player) => (
+            <Typography key={player.id}>{player.name}</Typography>
+          ))}
+        </section>
+      ) : (
+        <section className={classes.content}>
+          {player ? (
+            <>
+              <Typography variant="h2">{`Welcome, ${player.name}!`}</Typography>
+              <Typography>
+                Waiting for {space.host.name} to start the game
+              </Typography>
+            </>
+          ) : (
+            <>
+              <Typography variant="h2">Welcome!</Typography>
+              <section className={classes.nickname}>
+                <Typography>Set a nickname</Typography>
+                <TextField
+                  className={classes.textField}
+                  placeholder="Nickname"
+                  onChange={(event) => setNickname(event.target.value)}
+                  variant="outlined"
+                ></TextField>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="large"
+                  onClick={() => {
+                    connection.joinGame(nickname);
+                    setPlayer({ id: connection.socket.id, name: nickname });
+                  }}
+                >
+                  I'm ready!
+                </Button>
+              </section>
+            </>
+          )}
+        </section>
       )}
-      {player && <p>Waiting for {players[0]?.name} to start the game</p>}
     </article>
   );
 };

--- a/src/app/components/WaitingRoom.tsx
+++ b/src/app/components/WaitingRoom.tsx
@@ -43,9 +43,12 @@ const useStyles = makeStyles({
     maxWidth: '30em',
     padding: '1em',
   },
+  players: {
+    padding: '1em',
+  },
 });
 
-const WaitingRoom: FC<Props> = ({ connection, space }) => {
+const WaitingRoom: FC<Props> = ({ connection, space, onStartGame }) => {
   const { players, isHost, player, setPlayer } = useSpace();
   const [nickname, setNickname] = useState('');
   const classes = useStyles();
@@ -66,10 +69,20 @@ const WaitingRoom: FC<Props> = ({ connection, space }) => {
               href={`${window.location.origin}/${space.id}`}
             >{`${window.location.origin}/${space.id}`}</a>
           </section>
-          <Typography variant="h3">Friends who are here...</Typography>
-          {players.map((player) => (
-            <Typography key={player.id}>{player.name}</Typography>
-          ))}
+          <section className={classes.players}>
+            <Typography variant="h3">Friends who are here...</Typography>
+            {players.map((player) => (
+              <Typography key={player.id}>{player.name}</Typography>
+            ))}
+          </section>
+          <Button
+            variant="contained"
+            color="primary"
+            size="large"
+            onClick={onStartGame}
+          >
+            Start game!
+          </Button>
         </section>
       ) : (
         <section className={classes.content}>

--- a/src/app/components/WaitingRoom.tsx
+++ b/src/app/components/WaitingRoom.tsx
@@ -11,7 +11,6 @@ import Button from '@material-ui/core/Button';
 interface Props {
   space: Space;
   connection: Connection;
-  onStartGame: () => void;
 }
 const useStyles = makeStyles({
   main: {
@@ -48,7 +47,7 @@ const useStyles = makeStyles({
   },
 });
 
-const WaitingRoom: FC<Props> = ({ connection, space, onStartGame }) => {
+const WaitingRoom: FC<Props> = ({ connection, space }) => {
   const { players, isHost, player, setPlayer } = useSpace();
   const [nickname, setNickname] = useState('');
   const classes = useStyles();
@@ -79,7 +78,7 @@ const WaitingRoom: FC<Props> = ({ connection, space, onStartGame }) => {
             variant="contained"
             color="primary"
             size="large"
-            onClick={onStartGame}
+            onClick={connection.startGame}
           >
             Start game!
           </Button>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 
 import './less/main.less';
 import App from './App';
@@ -7,9 +8,21 @@ import { SpaceProvider } from './state/SpaceContext';
 
 const rootElement = document.querySelector('#root');
 
+const theme = createMuiTheme({
+  overrides: {
+    MuiTypography: {
+      h1: {
+        fontSize: '3rem',
+      },
+    },
+  },
+});
+
 render(
-  <SpaceProvider>
-    <App />
-  </SpaceProvider>,
+  <ThemeProvider theme={theme}>
+    <SpaceProvider>
+      <App />
+    </SpaceProvider>
+  </ThemeProvider>,
   rootElement
 );

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -12,7 +12,13 @@ const theme = createMuiTheme({
   overrides: {
     MuiTypography: {
       h1: {
-        fontSize: '3rem',
+        fontSize: '50px',
+      },
+      h2: {
+        fontSize: '35px',
+      },
+      h3: {
+        fontSize: '25px',
       },
     },
   },

--- a/src/app/less/main.less
+++ b/src/app/less/main.less
@@ -1,3 +1,6 @@
-body {
+html,
+body,
+#root {
   height: 100%;
+  margin: 0;
 }

--- a/src/app/state/SpaceContext.tsx
+++ b/src/app/state/SpaceContext.tsx
@@ -11,6 +11,7 @@ const [SpaceProvider, useSpace] = createUseContext(() => {
   const [players, setPlayers] = useState<Array<Player>>([]);
   const isHost = space?.host.id === connection?.socket.id;
   const [player, setPlayer] = useState<Player>();
+  const [isGameStarted, setGameStarted] = useState(false);
 
   return {
     space,
@@ -24,11 +25,19 @@ const [SpaceProvider, useSpace] = createUseContext(() => {
     player,
     setPlayer,
     isHost,
+    isGameStarted,
+    setGameStarted,
   };
 });
 
 export const useConnectToSpace = () => {
-  const { setConnection, setMessages, setPlayers, setSpace } = useSpace();
+  const {
+    setConnection,
+    setMessages,
+    setPlayers,
+    setSpace,
+    setGameStarted,
+  } = useSpace();
   return useCallback((path: string) => {
     const connection = Connection.setupConnection(path);
 
@@ -48,6 +57,11 @@ export const useConnectToSpace = () => {
         setPlayers(players);
       }
     );
+
+    connection.on(SocketEvent.StartGame, () => {
+      setMessages((messages) => [...messages, `Starting game...`]);
+      setGameStarted(true);
+    });
 
     connection.on(SocketEvent.ChatMessage, (message: string) => {
       console.log(`${SocketEvent.ChatMessage}: ${message}`);

--- a/src/server/web-server.ts
+++ b/src/server/web-server.ts
@@ -50,6 +50,9 @@ const createSpace = (space: Space) => {
     socket.on(SocketEvent.ChatMessage, (message: string) => {
       nsp.emit(SocketEvent.ChatMessage, message);
     });
+    socket.on(SocketEvent.StartGame, () => {
+      nsp.emit(SocketEvent.StartGame);
+    });
     socket.on(SocketEvent.Drawing, (drawing: Drawing) => {
       console.log(`Received drawing from ${drawing.artist}`);
       nsp.emit(SocketEvent.Drawing, drawing);

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -4,4 +4,5 @@ export enum SocketEvent {
   NewPlayer = 'NewPlayer',
   ChatMessage = 'ChatMessage',
   Drawing = 'Drawing',
+  StartGame = 'StartGame',
 }


### PR DESCRIPTION
Har lagt til styling for _WaitingRoom_ og _CreateSpace_. Og fikset flyt slik at _CreateSpace_ vises først om man ikke har spaceId i url, deretter _WaitingRoom_. Når Host trykke _start game_ skal _Game_ vises for alle i rommet.


_WaitingRoom_ håndterer fortsatt logikk for både host og vanlig player, det kan kanskje splittes opp senere?

Jeg har brukt det material biblioteket sin styling metode, så at du brukte styled components. Vi burde kanskje snakke om en felles må å gjøre styling på. Vi har jo også en .less fil. 

Jeg har også lyst til ved en senere anledning gjøre websocket events til serveren mer generisk, slik at vi slipper å gjøre endringer på serveren hver gang vi lager ny event.

![image](https://user-images.githubusercontent.com/2300790/82094657-cb4dfe80-96fd-11ea-8aba-b50809bf81a6.png)
![image](https://user-images.githubusercontent.com/2300790/82094685-d7d25700-96fd-11ea-8f5e-f04a494fdbde.png)
![image](https://user-images.githubusercontent.com/2300790/82094727-ea4c9080-96fd-11ea-8c77-72af121e1c68.png)
