### PR TITLE
Generaliser socket events og forbedre chat

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "presets": ["@babel/env", "@babel/typescript"],
-  "plugins": ["@babel/proposal-optional-chaining"]
+  "plugins": [
+    "@babel/proposal-optional-chaining",
+    "@babel/plugin-proposal-class-properties"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,6 +478,16 @@
         "@babel/plugin-syntax-async-generators": "^7.8.0"
       }
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+      "integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-typescript": "^7.9.0",

--- a/src/app/components/ChatPanel.tsx
+++ b/src/app/components/ChatPanel.tsx
@@ -4,10 +4,12 @@ import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import Icon from '@material-ui/core/Icon';
 import { makeStyles } from '@material-ui/core/styles';
+import { Player } from '../../types/models';
+import { useSpace } from '../state/SpaceContext';
 
 interface Props {
   messages: Array<string>;
-  onSendMessage: (message: string) => void;
+  onSendMessage: (message: string, sender: Player) => void;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -23,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
 
 const ChatPanel: FC<Props> = ({ messages, onSendMessage }) => {
   const [text, setText] = useState('');
+  const { player } = useSpace();
   const classes = useStyles();
   return (
     <Paper variant="outlined">
@@ -39,7 +42,7 @@ const ChatPanel: FC<Props> = ({ messages, onSendMessage }) => {
           fullWidth={true}
           onChange={(event) => setText(event.target.value)}
           InputProps={{
-            endAdornment: (
+            endAdornment: player && (
               <Button
                 variant="contained"
                 color="primary"
@@ -48,7 +51,7 @@ const ChatPanel: FC<Props> = ({ messages, onSendMessage }) => {
                 endIcon={<Icon fontSize="small">send</Icon>}
                 onClick={() => {
                   setText('');
-                  onSendMessage(text);
+                  onSendMessage(text, player);
                 }}
               >
                 Send

--- a/src/app/components/ChatPanel.tsx
+++ b/src/app/components/ChatPanel.tsx
@@ -7,6 +7,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Player } from '../../types/models';
 import { useSpace } from '../state/SpaceContext';
 
+const ENTER_KEY = 13;
+
 interface Props {
   messages: Array<string>;
   onSendMessage: (message: string, sender: Player) => void;
@@ -20,6 +22,7 @@ const useStyles = makeStyles((theme) => ({
     height: '200px',
     overflow: 'scroll',
     padding: '1em',
+    textAlign: 'left',
   },
 }));
 
@@ -34,32 +37,40 @@ const ChatPanel: FC<Props> = ({ messages, onSendMessage }) => {
           <p key={i}>{message}</p>
         ))}
       </section>
-      <section>
-        <TextField
-          variant="filled"
-          value={text}
-          size="small"
-          fullWidth={true}
-          onChange={(event) => setText(event.target.value)}
-          InputProps={{
-            endAdornment: player && (
-              <Button
-                variant="contained"
-                color="primary"
-                size="small"
-                className={classes.button}
-                endIcon={<Icon fontSize="small">send</Icon>}
-                onClick={() => {
-                  setText('');
-                  onSendMessage(text, player);
-                }}
-              >
-                Send
-              </Button>
-            ),
-          }}
-        />
-      </section>
+      {player && (
+        <section>
+          <TextField
+            variant="filled"
+            value={text}
+            size="small"
+            fullWidth={true}
+            onChange={(event) => setText(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.keyCode === ENTER_KEY) {
+                setText('');
+                onSendMessage(text, player);
+              }
+            }}
+            InputProps={{
+              endAdornment: (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  className={classes.button}
+                  endIcon={<Icon fontSize="small">send</Icon>}
+                  onClick={() => {
+                    setText('');
+                    onSendMessage(text, player);
+                  }}
+                >
+                  Send
+                </Button>
+              ),
+            }}
+          />
+        </section>
+      )}
     </Paper>
   );
 };

--- a/src/app/components/CreateSpace.tsx
+++ b/src/app/components/CreateSpace.tsx
@@ -35,7 +35,7 @@ const CreateSpace: FC = () => {
   const classes = useStyles();
 
   useEffect(() => {
-    setConnection(Connection.setupConnection('/'));
+    setConnection(new Connection('/'));
   }, []);
 
   if (!connection) {

--- a/src/app/state/GameContext.tsx
+++ b/src/app/state/GameContext.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import createUseContext from 'constate';
 import { Drawing, Game, Player } from '../../types/models';
 import { Connection } from '../api/Connection';
-import { SocketEvent } from '../../types/enums';
+import { BroadcastType } from '../../types/api';
 
 const initialState: Game = {
   players: [
@@ -27,9 +27,13 @@ const [GameProvider, useGame] = createUseContext(
       connection.sendDrawing(drawing);
     };
 
-    connection.on(SocketEvent.Drawing, (drawing: Drawing) => {
-      console.log(`${SocketEvent.Drawing}: Drawing from ${drawing.artist}`);
-      setGame({ ...game, drawings: [...game.drawings, drawing] });
+    connection.onBroadcast((payload) => {
+      switch (payload.type) {
+        case BroadcastType.Drawing: {
+          console.log(`Drawing from ${payload.drawing.artist}`);
+          setGame({ ...game, drawings: [...game.drawings, payload.drawing] });
+        }
+      }
     });
 
     return { game, setGame, sendDrawing, player, setWord, word };

--- a/src/app/state/GameContext.tsx
+++ b/src/app/state/GameContext.tsx
@@ -32,6 +32,7 @@ const [GameProvider, useGame] = createUseContext(
         case BroadcastType.Drawing: {
           console.log(`Drawing from ${payload.drawing.artist}`);
           setGame({ ...game, drawings: [...game.drawings, payload.drawing] });
+          break;
         }
       }
     });

--- a/src/app/state/SpaceContext.tsx
+++ b/src/app/state/SpaceContext.tsx
@@ -13,13 +13,23 @@ const [SpaceProvider, useSpace] = createUseContext(() => {
   const [player, setPlayer] = useState<Player>();
   const [isGameStarted, setGameStarted] = useState(false);
 
+  const addMessage = useCallback(
+    (message: string, sender: string = 'system') => {
+      setMessages((messages) => [
+        ...messages,
+        `[${new Date().toLocaleTimeString('en-GB')}] ${sender}: ${message}`,
+      ]);
+    },
+    [setMessages]
+  );
+
   return {
     space,
     setSpace,
     connection,
     setConnection,
     messages,
-    setMessages,
+    addMessage,
     players,
     setPlayers,
     player,
@@ -33,7 +43,7 @@ const [SpaceProvider, useSpace] = createUseContext(() => {
 export const useConnectToSpace = () => {
   const {
     setConnection,
-    setMessages,
+    addMessage,
     setPlayers,
     setSpace,
     setGameStarted,
@@ -50,10 +60,7 @@ export const useConnectToSpace = () => {
       SocketEvent.NewPlayer,
       (name: string, players: Array<Player>) => {
         console.log(`${SocketEvent.NewPlayer}: ${name}`);
-        setMessages((messages) => [
-          ...messages,
-          `${name} has joined the game.`,
-        ]);
+        addMessage(`${name} has joined the game.`);
         setPlayers(players);
       }
     );
@@ -62,11 +69,13 @@ export const useConnectToSpace = () => {
       switch (payload.type) {
         case BroadcastType.ChatMessage: {
           console.log(`${BroadcastType.ChatMessage}: ${payload.message}`);
-          setMessages((messages) => [...messages, payload.message]);
+          addMessage(payload.message, payload.sender.name);
+          break;
         }
         case BroadcastType.StartGame: {
-          setMessages((messages) => [...messages, `Starting game...`]);
+          addMessage('Starting game...');
           setGameStarted(true);
+          break;
         }
       }
     });

--- a/src/server/web-server.ts
+++ b/src/server/web-server.ts
@@ -4,9 +4,8 @@ import path from 'path';
 import SocketServer from 'socket.io';
 import uniqid from 'uniqid';
 
-import { SocketEvent } from '../types/enums';
-import { Drawing, Player, Space } from '../types/models';
-import { CreateSpaceRequest } from '../types/api';
+import { Player, Space } from '../types/models';
+import { Broadcast, CreateSpaceRequest, SocketEvent } from '../types/api';
 
 const app = express();
 const port = process.env.PORT || 5555;
@@ -47,15 +46,10 @@ const createSpace = (space: Space) => {
       players.push({ id: socket.id, name });
       nsp.emit(SocketEvent.NewPlayer, name, players);
     });
-    socket.on(SocketEvent.ChatMessage, (message: string) => {
-      nsp.emit(SocketEvent.ChatMessage, message);
-    });
-    socket.on(SocketEvent.StartGame, () => {
-      nsp.emit(SocketEvent.StartGame);
-    });
-    socket.on(SocketEvent.Drawing, (drawing: Drawing) => {
-      console.log(`Received drawing from ${drawing.artist}`);
-      nsp.emit(SocketEvent.Drawing, drawing);
+
+    socket.on(SocketEvent.BroadcastPayload, (payload: Broadcast) => {
+      console.log(`BROADCAST PAYLOAD: Broadcasting ${payload.type}`);
+      nsp.emit(SocketEvent.BroadcastPayload, payload);
     });
   });
 };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,39 @@
+import { Drawing, Player } from './models';
+
 export interface CreateSpaceRequest {
   hostId: string;
   hostName: string;
 }
+
+export enum SocketEvent {
+  Welcome = 'Welcome',
+  JoinGame = 'JoinGame',
+  NewPlayer = 'NewPlayer',
+  BroadcastPayload = 'BroadcastPayload',
+}
+
+export enum BroadcastType {
+  ChatMessage,
+  Drawing,
+  StartGame,
+}
+
+export interface BroadcastChatMessage {
+  type: BroadcastType.ChatMessage;
+  sender: Player;
+  message: string;
+}
+
+export interface BroadcastDrawing {
+  type: BroadcastType.Drawing;
+  drawing: Drawing;
+}
+
+export interface BroadcastStartGame {
+  type: BroadcastType.StartGame;
+}
+
+export type Broadcast =
+  | BroadcastChatMessage
+  | BroadcastDrawing
+  | BroadcastStartGame;

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,8 +1,0 @@
-export enum SocketEvent {
-  Welcome = 'Welcome',
-  JoinGame = 'JoinGame',
-  NewPlayer = 'NewPlayer',
-  ChatMessage = 'ChatMessage',
-  Drawing = 'Drawing',
-  StartGame = 'StartGame',
-}


### PR DESCRIPTION
For socket events som skal kun broadcastes til alle spillere uten at det skjer noen sideeffekter på serveren har jeg lagd en egen event for det, `SocketEvent. BroadcastPayload`, som har en tilhørende payload. Denne payloaden har litt mer typesikring enn det vanlige socket.io events har.

Har også lagt til _timestamp_ og _sender_ på chatmeldinger + så kan man sende meldinger med _Enter_.